### PR TITLE
Update to latest Microsoft.Quantum packages

### DIFF
--- a/src/Simulation/Simulators/Microsoft.Quantum.Simulation.Simulators.Qrack.csproj
+++ b/src/Simulation/Simulators/Microsoft.Quantum.Simulation.Simulators.Qrack.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.20082513" />
-    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.12.20082513" />
-    <PackageReference Include="Microsoft.Quantum.Runtime.Core" Version="0.12.20082513" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082513" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.20100504" />
+    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.12.20100504" />
+    <PackageReference Include="Microsoft.Quantum.Runtime.Core" Version="0.12.20100504" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20100504" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/src/Simulation/Simulators/QrackSimulator/Assert.cs
+++ b/src/Simulation/Simulators/QrackSimulator/Assert.cs
@@ -6,14 +6,13 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Quantum.Simulation.Core;
-using Microsoft.Quantum.Simulation.Simulators;
 using static System.Math;
 
 namespace Microsoft.Quantum.Simulation.Simulators.Qrack
 {
     public partial class QrackSimulator
     {
-        public class QrackSimAssert : Quantum.Intrinsic.Assert
+        public class QrackSimAssert : Microsoft.Quantum.Diagnostics.AssertMeasurement
         {
             [DllImport(QRACKSIM_DLL_NAME, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl, EntryPoint = "JointEnsembleProbability")]
             private static extern double JointEnsembleProbability(uint id, uint n, Pauli[] b, uint[] q);
@@ -25,11 +24,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> __Body__ => (_args) =>
             {
                 var (paulis, qubits, result, msg) = _args;
 
-                this.Simulator.CheckQubits(qubits);
+                this.Simulator.CheckAndPreserveQubits(qubits);
 
                 if (paulis.Length != qubits.Length)
                 {
@@ -51,11 +50,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> AdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, string), QVoid> __AdjointBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> ControlledBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> __ControlledBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> ControlledAdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, string)), QVoid> __ControlledAdjointBody__ => (_args) => { return QVoid.Instance; };
         }
     }
 }

--- a/src/Simulation/Simulators/QrackSimulator/AssertProb.cs
+++ b/src/Simulation/Simulators/QrackSimulator/AssertProb.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
 {
     public partial class QrackSimulator
     {
-        public class QrackSimAssertProb : Quantum.Intrinsic.AssertProb
+        public class QrackSimAssertProb : Microsoft.Quantum.Diagnostics.AssertMeasurementProbability
         {
             [DllImport(QRACKSIM_DLL_NAME, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl, EntryPoint = "JointEnsembleProbability")]
             private static extern double JointEnsembleProbability(uint id, uint n, Pauli[] b, uint[] q);
@@ -25,11 +25,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> __Body__ => (_args) =>
             {
                 var (paulis, qubits, result, expectedPr, msg, tol) = _args;
 
-                Simulator.CheckQubits(qubits);
+                Simulator.CheckAndPreserveQubits(qubits);
 
                 if (paulis.Length != qubits.Length)
                 {
@@ -68,11 +68,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> AdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double), QVoid> __AdjointBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> ControlledBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> __ControlledBody__ => (_args) => { return QVoid.Instance; };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> ControlledAdjointBody => (_args) => { return QVoid.Instance; };
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, IQArray<Qubit>, Result, double, string, double)), QVoid> __ControlledAdjointBody__ => (_args) => { return QVoid.Instance; };
         }
     }
 }

--- a/src/Simulation/Simulators/QrackSimulator/Dump.cs
+++ b/src/Simulation/Simulators/QrackSimulator/Dump.cs
@@ -63,17 +63,17 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
             }
         }
 
-        public class QsimDumpMachine<T> : Quantum.Diagnostics.DumpMachine<T>
+        public class QrackSimDumpMachine<T> : Quantum.Diagnostics.DumpMachine<T>
         {
             private QrackSimulator Simulator { get; }
 
 
-            public QsimDumpMachine(QrackSimulator m) : base(m)
+            public QrackSimDumpMachine(QrackSimulator m) : base(m)
             {
                 this.Simulator = m;
             }
 
-            public override Func<T, QVoid> Body => (location) =>
+            public override Func<T, QVoid> __Body__ => (location) =>
             {
                 if (location == null) { throw new ArgumentNullException(nameof(location)); }
 
@@ -91,12 +91,12 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<(T, IQArray<Qubit>), QVoid> Body => (__in) =>
+            public override Func<(T, IQArray<Qubit>), QVoid> __Body__ => (__in) =>
             {
                 var (location, qubits) = __in;
 
                 if (location == null) { throw new ArgumentNullException(nameof(location)); }
-                Simulator.CheckQubits(qubits);
+                Simulator.CheckAndPreserveQubits(qubits);
 
                 return Simulator.Dump(location, qubits);
             };

--- a/src/Simulation/Simulators/QrackSimulator/Exp.cs
+++ b/src/Simulation/Simulators/QrackSimulator/Exp.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> __Body__ => (_args) =>
             {
                 var (paulis, theta, qubits) = _args;
 
@@ -43,14 +43,14 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> AdjointBody => (_args) =>
+            public override Func<(IQArray<Pauli>, double, IQArray<Qubit>), QVoid> __AdjointBody__ => (_args) =>
             {
                 var (paulis, angle, qubits) = _args;
 
-                return this.Body.Invoke((paulis, -angle, qubits));
+                return this.__Body__.Invoke((paulis, -angle, qubits));
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> __ControlledBody__ => (_args) =>
             {
                 var (ctrls, (paulis, angle, qubits)) = _args;
 
@@ -63,17 +63,17 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 }
 
                 SafeControlled(ctrls,
-                    () => this.Body.Invoke((paulis, angle, qubits)),
+                    () => this.__Body__.Invoke((paulis, angle, qubits)),
                     (count, ids) => MCExp(Simulator.Id, (uint)paulis.Length, paulis.ToArray(), angle, count, ids, qubits.GetIds()));
 
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, double, IQArray<Qubit>)), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 var (ctrls, (paulis, angle, qubits)) = _args;
 
-                return this.ControlledBody.Invoke((ctrls, (paulis, -angle, qubits)));
+                return this.__ControlledBody__.Invoke((ctrls, (paulis, -angle, qubits)));
             };
         }
     }

--- a/src/Simulation/Simulators/QrackSimulator/ExpFrac.cs
+++ b/src/Simulation/Simulators/QrackSimulator/ExpFrac.cs
@@ -19,32 +19,32 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
             public static double Angle(long numerator, long power) =>
                 (System.Math.PI * numerator) / (1 << (int)power);
 
-            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> Body => (args) =>
+            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> __Body__ => (args) =>
             {
                 var (paulis, numerator, power, qubits) = args;
                 var angle = Angle(numerator, power);
-                return Exp.Apply((paulis, angle, qubits));
+                return Exp__.Apply((paulis, angle, qubits));
             };
 
-            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> AdjointBody => (args) =>
+            public override Func<(IQArray<Pauli>, long, long, IQArray<Qubit>), QVoid> __AdjointBody__ => (args) =>
             {
                 var (paulis, numerator, power, qubits) = args;
                 var angle = Angle(numerator, power);
-                return Exp.Adjoint.Apply((paulis, angle, qubits));
+                return Exp__.Adjoint.Apply((paulis, angle, qubits));
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, (paulis, numerator, power, qubits)) = args;
                 var angle = Angle(numerator, power);
-                return Exp.Controlled.Apply((ctrls, (paulis, angle, qubits)));
+                return Exp__.Controlled.Apply((ctrls, (paulis, angle, qubits)));
             };
 
-            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> ControlledAdjointBody => (args) =>
+            public override Func<(IQArray<Qubit>, (IQArray<Pauli>, long, long, IQArray<Qubit>)), QVoid> __ControlledAdjointBody__ => (args) =>
             {
                 var (ctrls, (paulis, numerator, power, qubits)) = args;
                 var angle = Angle(numerator, power);
-                return Exp.Adjoint.Controlled.Apply((ctrls, (paulis, angle, qubits)));
+                return Exp__.Adjoint.Controlled.Apply((ctrls, (paulis, angle, qubits)));
             };
         }
     }

--- a/src/Simulation/Simulators/QrackSimulator/H.cs
+++ b/src/Simulation/Simulators/QrackSimulator/H.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
             };
 
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, q1) = args;
 

--- a/src/Simulation/Simulators/QrackSimulator/M.cs
+++ b/src/Simulation/Simulators/QrackSimulator/M.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, Result> Body => (q) =>
+            public override Func<Qubit, Result> __Body__ => (q) =>
             {
                 Simulator.CheckQubit(q);
-
+                //setting qubit as measured to allow for release
+                q.IsMeasured = true;
                 return M(Simulator.Id, (uint)q.Id).ToResult();
             };
         }

--- a/src/Simulation/Simulators/QrackSimulator/Measure.cs
+++ b/src/Simulation/Simulators/QrackSimulator/Measure.cs
@@ -22,17 +22,20 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<(IQArray<Pauli>, IQArray<Qubit>), Result> Body => (_args) =>
+            public override Func<(IQArray<Pauli>, IQArray<Qubit>), Result> __Body__ => (_args) =>
             {
                 var (paulis, qubits) = _args;
 
                 Simulator.CheckQubits(qubits);
-
                 if (paulis.Length != qubits.Length)
                 {
                     throw new InvalidOperationException($"Both input arrays for {this.GetType().Name} (paulis,qubits), must be of same size");
                 }
-
+                foreach (Qubit q in qubits)
+                {
+                    //setting qubit as measured to allow for release
+                    q.IsMeasured = true;
+                }
                 return Measure(Simulator.Id, (uint)paulis.Length, paulis.ToArray(), qubits.GetIds()).ToResult();
             };
         }

--- a/src/Simulation/Simulators/QrackSimulator/QrackSimulator.cs
+++ b/src/Simulation/Simulators/QrackSimulator/QrackSimulator.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using Microsoft.Quantum.Simulation.Core;
 using Microsoft.Quantum.Simulation.Common;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.Quantum.Simulation.Simulators.Exceptions;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -33,27 +35,25 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
         [DllImport(QRACKSIM_DLL_NAME, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl, EntryPoint = "seed")]
         private static extern void SetSeed(uint id, UInt32 seedValue);
 
-        public uint Seed{ get; private set; }
-
         /// <summary>
         /// Creates a an instance of a quantum simulator.
         /// </summary>
         /// <param name="throwOnReleasingQubitsNotInZeroState"> If set to true, the exception is thrown when trying to release qubits not in zero state. </param>
         /// <param name="randomNumberGeneratorSeed"> Seed for the random number generator used by a simulator for measurement outcomes and the Random operation. </param>
         /// <param name="disableBorrowing"> If true, Borrowing qubits will be disabled, and a new qubit will be allocated instead every time borrowing is requested. Performance may improve. </param>
-        public QrackSimulator
-(
+        public QrackSimulator(
             bool throwOnReleasingQubitsNotInZeroState = true,
             UInt32? randomNumberGeneratorSeed = null,
             bool disableBorrowing = false)
-            : base(new QrackSimQubitManager(throwOnReleasingQubitsNotInZeroState, disableBorrowing : disableBorrowing))
+        : base(
+            new QrackSimQubitManager(throwOnReleasingQubitsNotInZeroState, disableBorrowing : disableBorrowing),
+            (int?)randomNumberGeneratorSeed
+        )
         {
-            Seed = (randomNumberGeneratorSeed.HasValue)
-             ? randomNumberGeneratorSeed.Value
-             : (uint)Guid.NewGuid().GetHashCode();
-
             Id = Init();
-            SetSeed(this.Id, this.Seed);
+            // Make sure that the same seed used by the built-in System.Random
+            // instance is also used by the native simulator itself.
+            SetSeed(this.Id, (uint)this.Seed);
             ((QrackSimQubitManager)QubitManager).Init(Id);
         }
 
@@ -92,28 +92,35 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
 
         /// <summary>
         ///     Makes sure the target qubit of an operation is valid. In particular it checks that the qubit instance is not null.
+        ///     Also sets the isMeasured flag to false for each qubit
         /// </summary>
         void CheckQubit(Qubit q1)
         {
             if (q1 == null) throw new ArgumentNullException(nameof(q1), "Trying to perform a primitive operation on a null Qubit");
+            //setting qubit as not measured to not allow release in case of gate operation on qubit
+            q1.IsMeasured = false;
         }
 
         /// <summary>
         ///     Makes sure all qubits are valid as parameter of an intrinsic quantum operation. In particular it checks that 
         ///         - none of the qubits are null
         ///         - there are no duplicated qubits
+        ///     Also sets the isMeasured flag to false for each qubit
         /// </summary>
         bool[] CheckQubits(IQArray<Qubit> ctrls, Qubit q1)
         {
             bool[] used = new bool[((QrackSimQubitManager)QubitManager).MaxId];
 
             CheckQubitInUse(q1, used);
+            q1.IsMeasured = false;
 
             if (ctrls != null && ctrls.Length > 0)
             {
                 foreach (var q in ctrls)
                 {
                     CheckQubitInUse(q, used);
+                    //setting qubit as not measured to not allow release in case of gate operation on qubit
+                    q.IsMeasured = false;
                 }
             }
 
@@ -125,8 +132,32 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
         ///     Makes sure all qubits are valid as parameter of an intrinsic quantum operation. In particular it checks that 
         ///         - none of the qubits are null
         ///         - there are no duplicated qubits
+        ///     Also sets the isMeasured flag to false for each qubit
         /// </summary>
         bool[] CheckQubits(IQArray<Qubit> targets)
+        {
+            if (targets == null) throw new ArgumentNullException(nameof(targets), "Trying to perform an intrinsic operation on a null Qubit array.");
+            if (targets.Length == 0) throw new ArgumentNullException(nameof(targets), "Trying to perform an intrinsic operation on an empty Qubit array.");
+
+            bool[] used = new bool[((QrackSimQubitManager)QubitManager).MaxId];
+
+            foreach (var q in targets)
+            {
+                CheckQubitInUse(q, used);
+                //setting qubit as not measured to not allow release in case of gate operation on qubit
+                q.IsMeasured = false;
+            }
+
+            return used;
+        }
+
+        /// <summary>
+        ///     Intended to be used with simulator functions like Dump, Assert, AssertProb
+        ///     Makes sure all qubits are valid as parameter of an intrinsic quantum operation. In particular it checks that 
+        ///         - none of the qubits are null
+        ///         - there are no duplicated qubits
+        /// </summary>
+        bool[] CheckAndPreserveQubits(IQArray<Qubit> targets)
         {
             if (targets == null) throw new ArgumentNullException(nameof(targets), "Trying to perform an intrinsic operation on a null Qubit array.");
             if (targets.Length == 0) throw new ArgumentNullException(nameof(targets), "Trying to perform an intrinsic operation on an empty Qubit array.");
@@ -145,6 +176,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
         ///     Makes sure all qubits are valid as parameter of an intrinsic quantum operation. In particular it checks that 
         ///         - none of the qubits are null
         ///         - there are no duplicated qubits
+        ///     Also sets the isMeasured flag to false for each qubit
         /// </summary>
         bool[] CheckQubits(IQArray<Qubit> ctrls, IQArray<Qubit> targets)
         {
@@ -155,6 +187,8 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 foreach (var q in ctrls)
                 {
                     CheckQubitInUse(q, used);
+                    //setting qubit as not measured to not allow release in case of gate operation on qubit
+                    q.IsMeasured = false;
                 }
             }
 

--- a/src/Simulation/Simulators/QrackSimulator/Qubit.cs
+++ b/src/Simulation/Simulators/QrackSimulator/Qubit.cs
@@ -4,8 +4,10 @@
 using Microsoft.Quantum.Simulation.Common;
 using Microsoft.Quantum.Simulation.Core;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Microsoft.Quantum.Simulation.Simulators.Qrack
 {

--- a/src/Simulation/Simulators/QrackSimulator/QubitManager.cs
+++ b/src/Simulation/Simulators/QrackSimulator/QubitManager.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
 
             public uint SimulatorId { get; private set; }
 
-            public QrackSimQubitManager
-(bool throwOnReleasingQubitsNotInZeroState = true, long qubitCapacity = 32, bool mayExtendCapacity = true, bool disableBorrowing = false)
+            public QrackSimQubitManager(bool throwOnReleasingQubitsNotInZeroState = true, long qubitCapacity = 32, bool mayExtendCapacity = true, bool disableBorrowing = false)
                 : base(qubitCapacity, mayExtendCapacity, disableBorrowing)
             {
                 this.throwOnReleasingQubitsNotInZeroState = throwOnReleasingQubitsNotInZeroState;
@@ -64,13 +63,14 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 base.ReleaseOneQubit(qubit, usedOnlyForBorrowing);
                 if (qubit != null)
                 {
-                    bool areAllReleasedQubitsZero = ReleaseOne(this.SimulatorId, (uint)qubit.Id);
-                    if (!areAllReleasedQubitsZero && throwOnReleasingQubitsNotInZeroState)
+                    bool isReleasedQubitZero = ReleaseOne(this.SimulatorId, (uint)qubit.Id);
+                    if (!(isReleasedQubitZero || qubit.IsMeasured) && throwOnReleasingQubitsNotInZeroState)
                     {
                         throw new ReleasedQubitsAreNotInZeroState();
                     }
                 }
             }
         }
+
     }
 }

--- a/src/Simulation/Simulators/QrackSimulator/R.cs
+++ b/src/Simulation/Simulators/QrackSimulator/R.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<(Pauli, double, Qubit), QVoid> Body => (_args) =>
+            public override Func<(Pauli, double, Qubit), QVoid> __Body__ => (_args) =>
             {
                 var (basis, angle, q1) = _args;
 
@@ -38,14 +38,14 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<(Pauli, double, Qubit), QVoid> AdjointBody => (_args) =>
+            public override Func<(Pauli, double, Qubit), QVoid> __AdjointBody__ => (_args) =>
             {
                 var (basis, angle, q1) = _args;
 
-                return this.Body.Invoke((basis, -angle, q1));
+                return this.__Body__.Invoke((basis, -angle, q1));
             };
 
-            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> __ControlledBody__ => (_args) =>
             {
                 var (ctrls, (basis, angle, q1)) = _args;
 
@@ -53,18 +53,18 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 CheckAngle(angle);
 
                 SafeControlled(ctrls,
-                    () => this.Body.Invoke((basis, angle, q1)),
+                    () => this.__Body__.Invoke((basis, angle, q1)),
                     (count, ids) => MCR(Simulator.Id, basis, angle, count, ids, (uint)q1.Id));
 
                 return QVoid.Instance;
             };
 
 
-            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, double, Qubit)), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 var (ctrls, (basis, angle, q1)) = _args;
 
-                return this.ControlledBody.Invoke((ctrls, (basis, -angle, q1)));
+                return this.__ControlledBody__.Invoke((ctrls, (basis, -angle, q1)));
             };
         }
     }

--- a/src/Simulation/Simulators/QrackSimulator/RFrac.cs
+++ b/src/Simulation/Simulators/QrackSimulator/RFrac.cs
@@ -19,32 +19,32 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
             public static double Angle(long numerator, long power) =>
                 (-2.0 * System.Math.PI * numerator) / (1 << (int)power);
 
-            public override Func<(Pauli, long, long, Qubit), QVoid> Body => (args) =>
+            public override Func<(Pauli, long, long, Qubit), QVoid> __Body__ => (args) =>
             {
                 var (pauli, numerator, power, qubit) = args;
                 var angle = Angle(numerator, power);
-                return R.Apply((pauli, angle, qubit));
+                return R__.Apply((pauli, angle, qubit));
             };
 
-            public override Func<(Pauli, long, long, Qubit), QVoid> AdjointBody => (args) =>
+            public override Func<(Pauli, long, long, Qubit), QVoid> __AdjointBody__ => (args) =>
             {
                 var (pauli, numerator, power, qubit) = args;
                 var angle = Angle(numerator, power);
-                return R.Adjoint.Apply((pauli, angle, qubit));
+                return R__.Adjoint.Apply((pauli, angle, qubit));
             };
 
-            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, (pauli, numerator, power, qubit)) = args;
                 var angle = Angle(numerator, power);
-                return R.Controlled.Apply((ctrls, (pauli, angle, qubit)));
+                return R__.Controlled.Apply((ctrls, (pauli, angle, qubit)));
             };
 
-            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> ControlledAdjointBody => (args) =>
+            public override Func<(IQArray<Qubit>, (Pauli, long, long, Qubit)), QVoid> __ControlledAdjointBody__ => (args) =>
             {
                 var (ctrls, (pauli, numerator, power, qubit)) = args;
                 var angle = Angle(numerator, power);
-                return R.Adjoint.Controlled.Apply((ctrls, (pauli, angle, qubit)));
+                return R__.Adjoint.Controlled.Apply((ctrls, (pauli, angle, qubit)));
             };
         }
     }

--- a/src/Simulation/Simulators/QrackSimulator/S.cs
+++ b/src/Simulation/Simulators/QrackSimulator/S.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<Qubit, QVoid> AdjointBody => (q1) =>
+            public override Func<Qubit, QVoid> __AdjointBody__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -62,14 +62,14 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 
                 Simulator.CheckQubits(ctrls, q1);
 
                 SafeControlled(ctrls,
-                    () => this.AdjointBody(q1),
+                    () => this.__AdjointBody__(q1),
                     (count, ids) => MCAdjS(Simulator.Id, count, ids, (uint)q1.Id));
 
                 return QVoid.Instance;

--- a/src/Simulation/Simulators/QrackSimulator/StateDumper.cs
+++ b/src/Simulation/Simulators/QrackSimulator/StateDumper.cs
@@ -28,9 +28,9 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
             /// <summary>
             /// Basic constructor. Takes the simulator to probe.
             /// </summary>
-            public StateDumper(QrackSimulator qsim)
+            public StateDumper(QrackSimulator QrackSim)
             {
-                this.Simulator = qsim;
+                this.Simulator = QrackSim;
             }
 
             /// <summary>
@@ -76,7 +76,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
         {
             private int _maxCharsStateId;
 
-            public SimpleDumper(QrackSimulator qsim, Action<string> channel) : base(qsim)
+            public SimpleDumper(QrackSimulator QrackSim, Action<string> channel) : base(QrackSim)
             {
                 this.Channel = channel;
             }

--- a/src/Simulation/Simulators/QrackSimulator/T.cs
+++ b/src/Simulation/Simulators/QrackSimulator/T.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 
@@ -52,7 +52,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<Qubit, QVoid> AdjointBody => (q1) =>
+            public override Func<Qubit, QVoid> __AdjointBody__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
                 
@@ -60,14 +60,14 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledAdjointBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledAdjointBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 
                 Simulator.CheckQubits(ctrls, q1);
 
                 SafeControlled(ctrls,
-                    () => this.AdjointBody(q1),
+                    () => this.__AdjointBody__(q1),
                     (count, ids) => MCAdjT(Simulator.Id, count, ids, (uint)q1.Id));
 
                 return QVoid.Instance;

--- a/src/Simulation/Simulators/QrackSimulator/X.cs
+++ b/src/Simulation/Simulators/QrackSimulator/X.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (args) =>
             {
                 var (ctrls, q1) = args;
 

--- a/src/Simulation/Simulators/QrackSimulator/Y.cs
+++ b/src/Simulation/Simulators/QrackSimulator/Y.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1);
 
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 

--- a/src/Simulation/Simulators/QrackSimulator/Z.cs
+++ b/src/Simulation/Simulators/QrackSimulator/Z.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 this.Simulator = m;
             }
 
-            public override Func<Qubit, QVoid> Body => (q1) =>
+            public override Func<Qubit, QVoid> __Body__ => (q1) =>
             {
                 Simulator.CheckQubit(q1); ;
 
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
                 return QVoid.Instance;
             };
 
-            public override Func<(IQArray<Qubit>, Qubit), QVoid> ControlledBody => (_args) =>
+            public override Func<(IQArray<Qubit>, Qubit), QVoid> __ControlledBody__ => (_args) =>
             {
                 (IQArray<Qubit> ctrls, Qubit q1) = _args;
 

--- a/src/Simulation/Simulators/QrackSimulator/random.cs
+++ b/src/Simulation/Simulators/QrackSimulator/random.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
 {
     public partial class QrackSimulator
     {
-        public class QSimrandom : Quantum.Intrinsic.Random
+        public class QrackSimrandom : Quantum.Intrinsic.Random
         {
             [DllImport(QRACKSIM_DLL_NAME, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl, EntryPoint = "random_choice")]
             private static extern Int64 random_choice(uint id, Int64 size, double[] p);
@@ -17,12 +17,12 @@ namespace Microsoft.Quantum.Simulation.Simulators.Qrack
             private uint SimulatorId { get; }
 
 
-            public QSimrandom(QrackSimulator m) : base(m)
+            public QrackSimrandom(QrackSimulator m) : base(m)
             {
                 this.SimulatorId = m.Id;
             }
 
-            public override Func<IQArray<double>, Int64> Body => (p) =>
+            public override Func<IQArray<double>, Int64> __Body__ => (p) =>
             {
                 return random_choice(this.SimulatorId, p.Length, p.ToArray());
             };            


### PR DESCRIPTION
I grabbed the latest version of the C# simulator code that QrackSimulator was modified from, string-replaced the same way I originally did, (using the Qrack dll,) and updated to the latest Microsoft.Quantum packages. I want to get the latest runtime unit tests in this weekend, as well, but this likely already works with the current releases of components in the Microsoft Quantum SDK.